### PR TITLE
Fix/update to chrome 118

### DIFF
--- a/src/BaristaLabs.ChromeDevTools.RemoteInterface/CodeGen/ProtocolGenerator.cs
+++ b/src/BaristaLabs.ChromeDevTools.RemoteInterface/CodeGen/ProtocolGenerator.cs
@@ -131,9 +131,11 @@
                                 };
                             break;
                         case "array":
-                            if ((type.Items == null || String.IsNullOrWhiteSpace(type.Items.Type)) && type.Items.TypeReference != "StringIndex")
+                            if ((type.Items == null || String.IsNullOrWhiteSpace(type.Items.Type))
+                                && type.Items.TypeReference != "StringIndex"
+                                && type.Items.TypeReference != "FilterEntry")
                             {
-                                throw new NotImplementedException("Did not expect a top-level domain array type to specify a TypeReference");
+                                throw new NotImplementedException($"Did not expect array type {type.ToString()} of top-level domain {domain.ToString()} to specify a TypeReference");
                             }
 
                             string itemType;
@@ -153,6 +155,9 @@
                                     {
                                         case "StringIndex":
                                             itemType = "string";
+                                            break;
+                                        case "FilterEntry":
+                                            itemType = "FilterEntry";
                                             break;
                                         default:
                                             throw new NotImplementedException($"Did not expect a top-level domain array type to specify a type reference of {type.Items.TypeReference}");

--- a/src/ChromeDevToolsGeneratorCLI/Templates/ChromeSession.hbs
+++ b/src/ChromeDevToolsGeneratorCLI/Templates/ChromeSession.hbs
@@ -18,7 +18,7 @@
     {
         private readonly string m_endpointAddress;
         private readonly ILogger<ChromeSession> m_logger;
-        private readonly ConcurrentDictionary<string, ConcurrentBag<Action<object>>> m_eventHandlers = new ConcurrentDictionary<string, ConcurrentBag<Action<object>>>();
+        private readonly ConcurrentDictionary<object, ConcurrentBag<Action<object>>> m_eventHandlers = new ConcurrentDictionary<object, ConcurrentBag<Action<object>>>();
         private readonly ConcurrentDictionary<Type, string> m_eventTypeMap = new ConcurrentDictionary<Type, string>();
 
         private ActionBlock<string> m_messageQueue;
@@ -94,13 +94,13 @@
         /// <param name="millisecondsTimeout"></param>
         /// <param name="throwExceptionIfResponseNotReceived"></param>
         /// <returns></returns>
-        public async Task<ICommandResponse<TCommand>> SendCommand<TCommand>(TCommand command, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
+        public async Task<ICommandResponse<TCommand>> SendCommand<TCommand>(TCommand command, string sessionId = "", CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
             where TCommand : ICommand
         {
             if (command == null)
                 throw new ArgumentNullException(nameof(command));
 
-            var result = await SendCommand(command.CommandName, JToken.FromObject(command), cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
+            var result = await SendCommand(command.CommandName, JToken.FromObject(command), sessionId, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
 
             if (result == null)
                 return null;
@@ -121,14 +121,14 @@
         /// <param name="millisecondsTimeout"></param>
         /// <param name="throwExceptionIfResponseNotReceived"></param>
         /// <returns></returns>
-        public async Task<TCommandResponse> SendCommand<TCommand, TCommandResponse>(TCommand command, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
+        public async Task<TCommandResponse> SendCommand<TCommand, TCommandResponse>(TCommand command, string sessionId = "", CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
             where TCommand : ICommand
             where TCommandResponse : ICommandResponse<TCommand>
         {
             if (command == null)
                 throw new ArgumentNullException(nameof(command));
 
-            var result = await SendCommand(command.CommandName, JToken.FromObject(command), cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
+            var result = await SendCommand(command.CommandName, JToken.FromObject(command), sessionId, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
 
             if (result == null)
                 return default(TCommandResponse);
@@ -146,10 +146,13 @@
         /// <param name="throwExceptionIfResponseNotReceived"></param>
         /// <returns></returns>
         [DebuggerStepThrough]
-        public async Task<JToken> SendCommand(string commandName, JToken @params, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
+        public async Task<JToken> SendCommand(string commandName, JToken @params, string sessionId = "", CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
         {
+            sessionId = sessionId ?? "";
+
             var message = new
             {
+                sessionId,
                 id = Interlocked.Increment(ref m_currentCommandId),
                 method = commandName,
                 @params = @params
@@ -160,7 +163,7 @@
 
             await OpenSessionConnection(cancellationToken);
 
-            LogTrace("Sending {id} {method}: {params}", message.id, message.method, @params.ToString());
+            LogTrace("Sending: \nSessionId: {sessionId} \nID: {id} \nCommand Name: {method} \nCommand Params: {params}", sessionId, message.id, message.method, @params.ToString());
             
             var contents = JsonConvert.SerializeObject(message);
 
@@ -181,7 +184,7 @@
                 if (!String.IsNullOrWhiteSpace(errorData))
                     exceptionMessage = $"{exceptionMessage} - {errorData}";
 
-                LogTrace("Recieved Error Response {id}: {message} {data}", message.id, message, errorData);
+                LogTrace("Recieved Error Response: \nID: {id} \nRequest Message: {message} \nError Data: {data} \nException Message: {exceptionMessage}", message.id, message, errorData, exceptionMessage);
                 throw new CommandResponseException(exceptionMessage)
                 {
                     Code = m_lastResponse.Result.Value<long>("code")
@@ -195,9 +198,11 @@
         /// </summary>
         /// <typeparam name="TEvent">Event to subscribe to</typeparam>
         /// <param name="eventCallback"></param>
-        public void Subscribe<TEvent>(Action<TEvent> eventCallback)
+        public void Subscribe<TEvent>(Action<TEvent> eventCallback, string sessionId = "")
             where TEvent : IEvent
         {
+            sessionId = sessionId ?? "";
+
             if (eventCallback == null)
                 throw new ArgumentNullException(nameof(eventCallback));
 
@@ -212,7 +217,14 @@
                 });
 
             var callbackWrapper = new Action<object>(obj => eventCallback((TEvent)obj));
-            m_eventHandlers.AddOrUpdate(eventName,
+
+            var keyObj = new
+            {
+                SessionId = sessionId,
+                EventName = eventName
+            };
+
+            m_eventHandlers.AddOrUpdate(keyObj,
                 (m) => new ConcurrentBag<Action<object>>(new[] { callbackWrapper }),
                 (m, currentBag) =>
                 {
@@ -232,9 +244,17 @@
             }
         }
 
-        private void RaiseEvent(string methodName, JToken eventData)
+        private void RaiseEvent(string methodName, JToken eventData, string sessionId = "")
         {
-            if (m_eventHandlers.TryGetValue(methodName, out ConcurrentBag<Action<Object>> bag))
+            sessionId = sessionId ?? "";
+
+            var keyObj = new
+            {
+                SessionId = sessionId,
+                EventName = methodName
+            };
+
+            if (m_eventHandlers.TryGetValue(keyObj, out ConcurrentBag<Action<Object>> bag))
             {
                 if (!EventTypeMap.TryGetTypeForMethodName(methodName, out Type eventType))
                     throw new InvalidOperationException($"Unknown {methodName} does not correspond to a known event type.");
@@ -280,8 +300,11 @@
             {
                 var method = methodProperty.Value<string>();
                 var eventData = messageObject["params"];
-                LogTrace("Recieved Event {method}: {params}", method, eventData.ToString());
-                RaiseEvent(method, eventData);
+                var sessionId = messageObject.TryGetValue("sessionId", out JToken sessionIdProperty)
+                    ? sessionIdProperty.Value<string>()
+                    : "";
+                LogTrace("Recieved Event: \nEvent Name: {method} \nParams: {params} \nSessionId: {sessionId}", method, eventData.ToString(), sessionId);
+                RaiseEvent(method, eventData, sessionId);
                 return;
             }
 

--- a/src/ChromeDevToolsGeneratorCLI/Templates/ChromeSession.hbs
+++ b/src/ChromeDevToolsGeneratorCLI/Templates/ChromeSession.hbs
@@ -225,6 +225,7 @@
         {
             if (m_sessionSocket.State != WebSocketState.Open)
             {
+                m_openEvent.Reset();
                 m_sessionSocket.Open();
 
                 await Task.Run(() => m_openEvent.Wait(cancellationToken));

--- a/src/ChromeDevToolsGeneratorCLI/Templates/domain.hbs
+++ b/src/ChromeDevToolsGeneratorCLI/Templates/domain.hbs
@@ -28,9 +28,9 @@
         /// <summary>
         /// {{xml-code-comment Description 2}}
         /// </summary>
-        public async Task<{{dehumanize Name}}CommandResponse> {{dehumanize Name}}({{dehumanize Name}}Command command{{#if NoParameters}} = null{{/if}}, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
+        public async Task<{{dehumanize Name}}CommandResponse> {{dehumanize Name}}({{dehumanize Name}}Command command{{#if NoParameters}} = null{{/if}}, string sessionId = null, CancellationToken cancellationToken = default(CancellationToken), int? millisecondsTimeout = null, bool throwExceptionIfResponseNotReceived = true)
         {
-            return await m_session.SendCommand<{{dehumanize Name}}Command, {{dehumanize Name}}CommandResponse>(command{{#if NoParameters}} ?? new {{dehumanize Name}}Command(){{/if}}, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
+            return await m_session.SendCommand<{{dehumanize Name}}Command, {{dehumanize Name}}CommandResponse>(command{{#if NoParameters}} ?? new {{dehumanize Name}}Command(){{/if}}, sessionId, cancellationToken, millisecondsTimeout, throwExceptionIfResponseNotReceived);
         }
     {{/each}}
 
@@ -38,9 +38,9 @@
         /// <summary>
         /// {{xml-code-comment Description 2}}
         /// </summary>
-        public void SubscribeTo{{dehumanize Name}}Event(Action<{{dehumanize Name}}Event> eventCallback)
+        public void SubscribeTo{{dehumanize Name}}Event(Action<{{dehumanize Name}}Event> eventCallback, string sessionId = "")
         {
-            m_session.Subscribe(eventCallback);
+            m_session.Subscribe(eventCallback, sessionId);
         }
     {{/each}}
     }


### PR DESCRIPTION
Make the generator work with chrome version 118:
- Add support for FilterEntry.
- Fixed a bug with OpenSessionConnection not waiting until the socket has opened. This has sometimes caused issues for me during testing with many open chrome browsers.
- Switch to using flattened mode instead of the deprecated (and possibly no longer functional) non-flattened mode. The SendCommand and Subscribe methods now have a parameter to provide a sessionId, which is blank ("") by default to provide backwards compatibility. A blank sessionId sends the command or subscription to the target of the websocketdebuggerurl, otherwise it will send it to the target with the given sessionId. You get a sessionId by attaching to a target, which will return one. From my testing, everything seems backwards compatible but I believe some things may not be. You can read more here https://github.com/aslushnikov/getting-started-with-cdp/blob/master/README.md